### PR TITLE
Build drop based on photon

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,9 +34,9 @@
 					<url>https://sdqweb.ipd.kit.edu/eclipse/palladiosimulator/nightly</url>
 				</repository>
 				<repository>
-					<id>eclipse-oxygen</id>
+					<id>eclipse-photon</id>
 					<layout>p2</layout>
-					<url>http://ftp-stud.hs-esslingen.de/pub/Mirrors/eclipse/releases/oxygen/</url>
+					<url>http://download.eclipse.org/releases/photon/</url>
 				</repository>
 			</repositories>
 		</profile>
@@ -55,9 +55,9 @@
 					<url>https://sdqweb.ipd.kit.edu/eclipse/palladiosimulator/releases/latest</url>
 				</repository>
 				<repository>
-					<id>eclipse-oxygen</id>
+					<id>eclipse-photon</id>
 					<layout>p2</layout>
-					<url>http://ftp-stud.hs-esslingen.de/pub/Mirrors/eclipse/releases/oxygen/</url>
+					<url>http://download.eclipse.org/releases/photon/</url>
 				</repository>
 			</repositories>
 		</profile>


### PR DESCRIPTION
The current build runs on Eclipse Oxygen but that version has issues regarding Java 11 compatibility. Therefore, the new drop should be based on Eclipse Photon.

I did not use the latest release because it seems to have a serious issue with the model explorer, which makes it unusable.