### PR TITLE
Use environment variable to trigger release build.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,8 @@
 			<id>nightly</id>
 			<activation>
 				<property>
-					<name>!release</name>
+					<name>env.RELEASE</name>
+					<value>!true</value>
 				</property>
 			</activation>
 			<repositories>
@@ -45,7 +46,8 @@
 			<id>release</id>
 			<activation>
 				<property>
-					<name>release</name>
+					<name>env.RELEASE</name>
+					<value>true</value>
 				</property>
 			</activation>
 			<repositories>


### PR DESCRIPTION
The build server uses environment variables to decide if a build is a release build or not. The build definition should adhere to that convention.