### PR TITLE
Use 2020-12 as new target platform for product.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,9 +34,15 @@
 					<url>https://updatesite.palladio-simulator.com/palladio-build-updatesite/nightly/</url>
 				</repository>
 				<repository>
-					<id>eclipse-2020-06</id>
+					<id>eclipse-2020-12</id>
 					<layout>p2</layout>
-					<url>http://download.eclipse.org/releases/2020-06/</url>
+					<url>http://download.eclipse.org/releases/2020-12/</url>
+				</repository>
+				<!-- this should not be necessary anymore after 2020-12 release -->
+				<repository>
+					<id>parsley</id>
+					<layout>p2</layout>
+					<url>https://download.eclipse.org/emf-parsley/updates/</url>
 				</repository>
 			</repositories>
 		</profile>
@@ -55,9 +61,9 @@
 					<url>https://updatesite.palladio-simulator.com/palladio-build-updatesite/releases/latest</url>
 				</repository>
 				<repository>
-					<id>eclipse-2020-06</id>
+					<id>eclipse-2020-12</id>
 					<layout>p2</layout>
-					<url>http://download.eclipse.org/releases/2020-06/</url>
+					<url>http://download.eclipse.org/releases/2020-12/</url>
 				</repository>
 			</repositories>
 		</profile>


### PR DESCRIPTION
As discussed in the ConCall, I switched to 2012-12 for the product build. EMF Parsley does not seem available on the alpha 2020-12 update site, so I added it manually. I assume that this will change in the future, so I did not include the additional update site in the release profile.