### PR TITLE
PALLADIO-480 Remove workarounds feature.

### DIFF
--- a/features/org.palladiosimulator.product.feature/feature.xml
+++ b/features/org.palladiosimulator.product.feature/feature.xml
@@ -39,7 +39,6 @@
       <import feature="org.eclipse.jdt" version="3.18.0" match="compatible"/>
       <import feature="org.eclipse.platform" version="4.16.0" match="compatible"/>
       <import plugin="org.eclipse.sdk" version="4.16.0" match="compatible"/>
-      <import feature="org.palladiosimulator.supporting.workarounds.epackageinit.feature" version="4.3.0" match="equivalent"/>
       <import feature="org.palladiosimulator.measurementsui.feature" version="4.3.0" match="equivalent"/>
    </requires>
 


### PR DESCRIPTION
The workarounds feature is not required anymore. Therefore, it is removed.