### PR TITLE
Add SimuLizar Tooladapter to default drop

### DIFF
--- a/features/org.palladiosimulator.product.feature/feature.xml
+++ b/features/org.palladiosimulator.product.feature/feature.xml
@@ -34,6 +34,7 @@
       <import feature="org.palladiosimulator.analyzer.feature" version="5.0.0" match="equivalent"/>
       <import feature="org.palladiosimulator.monitorrepository.feature" version="5.0.0" match="equivalent"/>
       <import feature="org.palladiosimulator.simulizar.feature" version="5.0.0" match="equivalent"/>
+      <import feature="org.palladiosimulator.experimentautomation.application.tooladapter.simulizar.feature" version="5.0.0" match="equivalent"/>
       <import feature="org.palladiosimulator.simulation.abstractsimengine.desmoj.feature" version="5.0.0" match="equivalent"/>
       <import feature="org.palladiosimulator.measurementsui.feature" version="5.0.0" match="equivalent"/>
       <import feature="org.palladiosimulator.branding.feature"/>

--- a/products/org.palladiosimulator.product/org.palladiosimulator.palladiobench.product
+++ b/products/org.palladiosimulator.product/org.palladiosimulator.palladiobench.product
@@ -356,6 +356,7 @@ version(s), and exceptions or additional permissions here}."
       <feature id="org.palladiosimulator.analyzer.feature" installMode="root"/>
       <feature id="org.palladiosimulator.monitorrepository.feature" installMode="root"/>
       <feature id="org.palladiosimulator.simulizar.feature" installMode="root"/>
+      <feature id="org.palladiosimulator.experimentautomation.application.tooladapter.simulizar.feature" installMode="root"/>
       <feature id="org.palladiosimulator.simulation.abstractsimengine.desmoj.feature" installMode="root"/>
       <feature id="org.palladiosimulator.measurementsui.feature" installMode="root"/>
    </features>


### PR DESCRIPTION
It does not make sense to ship ExperimentAutomation Models and Application Framework (and consequently have it pop up in the Launch Config dialog) without shipping a tooladapter. As apparently experiment automation is required transitively by the editors, we should ship the SimuLizar tool adapter as well. 