### PR TITLE
PALLADIO-546 Add UI components of unified OCL to product.

### DIFF
--- a/features/org.palladiosimulator.product.feature/feature.xml
+++ b/features/org.palladiosimulator.product.feature/feature.xml
@@ -41,6 +41,7 @@
       <import feature="org.eclipse.jdt" version="3.18.0" match="compatible"/>
       <import feature="org.eclipse.platform" version="4.20.0" match="compatible"/>
       <import plugin="org.eclipse.sdk" version="4.20.0" match="compatible"/>
+      <import feature="org.eclipse.ocl.unified.ui" version="1.16.0" match="compatible"/>
    </requires>
 
 </feature>


### PR DESCRIPTION
This PR partially addresses [PALLADIO-546](https://palladio-simulator.atlassian.net/browse/PALLADIO-546). It fixes an evaluation error caused by missing UI dependencies of pivot OCL.