### PR TITLE
Migrate to parent POM version 0.10.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,8 +5,8 @@
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>org.palladiosimulator</groupId>
-		<artifactId>eclipse-parent-product</artifactId>
-		<version>0.9.0</version>
+		<artifactId>eclipse-parent</artifactId>
+		<version>0.10.0</version>
 	</parent>
 	<groupId>org.palladiosimulator.bench</groupId>
 	<artifactId>parent</artifactId>	
@@ -17,6 +17,19 @@
 		<module>features</module>
 		<module>products</module>
 	</modules>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.eclipse.tycho</groupId>
+				<artifactId>tycho-source-plugin</artifactId>
+				<version>${tycho.version}</version>
+				<configuration>
+					<skip>true</skip>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
 
 	<profiles>
 


### PR DESCRIPTION
- Migrate from parent POM version `0.9.0` to the new parent POM version `0.10.0`
- Integrate the contents of the intermediate parent POM `eclipse-parent-product` and now directly inherit from `eclipse-parent` (related PR: [Palladio-Build-MavenParent#60](https://github.com/PalladioSimulator/Palladio-Build-MavenParent/pull/60))
- Locally verified build success